### PR TITLE
build: Remove duplicate CI actions

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,6 +1,10 @@
 name: Ruby
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   rubocop:


### PR DESCRIPTION
Previously, we ran CI actions on pushes to any branch and on changes to a pull request, which resulted in duplicate events being run in pull requests. This commit changes the GitHub Actions build rules to only run CI on pushes to the *main* branch and on any changes to a pull request.