### PR TITLE
query: Add methods to create and drop caches

### DIFF
--- a/lib/readyset/query.rb
+++ b/lib/readyset/query.rb
@@ -93,7 +93,7 @@ module Readyset
     #
     # @return [void]
     def self.drop_all_caches!
-      ReadySet.raw_query('DROP ALL CACHES')
+      Readyset.raw_query('DROP ALL CACHES')
 
       nil
     end

--- a/readyset.gemspec
+++ b/readyset.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 6.1'
   spec.add_dependency 'rake', '~> 13.0'
 
+  spec.add_development_dependency 'factory_bot', '~> 6.4'
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'rubocop-airbnb'
 end

--- a/spec/factories/query.rb
+++ b/spec/factories/query.rb
@@ -1,0 +1,30 @@
+FactoryBot.define do
+  factory :query, class: Readyset::Query do
+    add_attribute(:'query id') { 'q_eafb620c78f5b9ac' }
+    count { '5' }
+
+    factory :cached_query do
+      add_attribute(:'query text') { 'SELECT * FROM "t" WHERE ("x" = $1)' }
+      add_attribute(:'cache name') { 'q_eafb620c78f5b9ac' }
+      add_attribute(:'fallback behavior') { 'fallback allowed' }
+
+    end
+
+    factory :seen_but_not_cached_query do
+      add_attribute(:'proxied query') { 'SELECT * FROM "t" WHERE ("x" = $1)' }
+      add_attribute(:'readyset supported') { 'yes' }
+
+      factory :pending_query do
+        add_attribute(:'readyset supported') { 'pending' }
+      end
+    end
+
+    factory :unsupported_query do
+      add_attribute(:'query id') { 'q_f9bfc11a043b2f75' }
+      add_attribute(:'proxied query') { 'SHOW TIME ZONE' }
+      add_attribute(:'readyset supported') { 'unsupported' }
+    end
+
+    initialize_with { new(attributes) }
+  end
+end

--- a/spec/factories/query.rb
+++ b/spec/factories/query.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :query, class: Readyset::Query do
+  factory :query, class: 'Readyset::Query' do
     add_attribute(:'query id') { 'q_eafb620c78f5b9ac' }
     count { '5' }
 
@@ -7,7 +7,6 @@ FactoryBot.define do
       add_attribute(:'query text') { 'SELECT * FROM "t" WHERE ("x" = $1)' }
       add_attribute(:'cache name') { 'q_eafb620c78f5b9ac' }
       add_attribute(:'fallback behavior') { 'fallback allowed' }
-
     end
 
     factory :seen_but_not_cached_query do

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Readyset::Query do
         build(:seen_but_not_cached_query),
         build(:seen_but_not_cached_query,
               :'query id' => 'q_8892818e62c34ecd',
-              :'proxied query' => 'SELECT * FROM "t" WHERE ("y" = $1)')
+              :'proxied query' => 'SELECT * FROM "t" WHERE ("y" = $1)'),
       ]
     end
     let(:unsupported_or_pending_queries) do
@@ -188,7 +188,8 @@ RSpec.describe Readyset::Query do
       let(:query) { build(:cached_query) }
       let(:query_id) { query.id }
 
-      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'SHOW CACHES WHERE query_id = ?' do
+      it_behaves_like 'a wrapper around a ReadySet SQL extension',
+'SHOW CACHES WHERE query_id = ?' do
         let(:args) { expected_output.id }
         let(:raw_query_result) { [attributes_for(:cached_query)] }
         let(:expected_output) { query }
@@ -344,7 +345,8 @@ RSpec.describe Readyset::Query do
 
         let(:name) { 'test cache' }
 
-        it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE ALWAYS ? FROM %s' do
+        it_behaves_like 'a wrapper around a ReadySet SQL extension',
+'CREATE CACHE ALWAYS ? FROM %s' do
           let(:args) { [name, query.id] }
 
           it 'invokes Readyset::Query#reload' do
@@ -445,7 +447,7 @@ RSpec.describe Readyset::Query do
     subject { query.reload }
 
     let(:query) { build(:seen_but_not_cached_query) }
-    let(:updated_query) { build(:cached_query, :'count' => '0') }
+    let(:updated_query) { build(:cached_query, :count => '0') }
 
     before do
       allow(Readyset::Query).to receive(:find).with(query.id).and_return(updated_query)

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ReadySet::Query do
           'proxied query' => 'SELECT * FROM "t" WHERE ("y" = $1)',
           'readyset supported' => 'yes',
           'count' => 5,
-        })
+        }),
       ]
     end
     let(:unsupported_or_pending_queries) do
@@ -491,7 +491,7 @@ RSpec.describe ReadySet::Query do
 
     context 'when the query does not have a cache name' do
       subject { seen_but_not_cached_query }
-        attrs = 
+
       it 'returns false' do
         expect(subject.cached?).to eq(false)
       end
@@ -614,13 +614,13 @@ RSpec.describe ReadySet::Query do
   private
 
   def cached_query_attributes
-      {
-        'query id' => query_id,
-        'query text' => 'SELECT * FROM "t" WHERE ("x" = $1)',
-        'cache name' => query_id,
-        'fallback behavior' => 'fallback allowed',
-        'count' => 5,
-      }
+    {
+      'query id' => query_id,
+      'query text' => 'SELECT * FROM "t" WHERE ("x" = $1)',
+      'cache name' => query_id,
+      'fallback behavior' => 'fallback allowed',
+      'count' => 5,
+    }
   end
 
   def cached_query

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -627,6 +627,15 @@ RSpec.describe ReadySet::Query do
     ReadySet::Query.new(cached_query_attributes)
   end
 
+  def expect_queries_to_be_equal(query1, query2)
+    query1.id == query2.id &&
+      query1.text == query2.text &&
+      query1.supported == query2.supported &&
+      query1.cache_name == query2.cache_name &&
+      query1.send(:fallback_behavior) == query2.send(:fallback_behavior) &&
+      query1.count == query2.count
+  end
+
   def query_id
     'q_eafb620c78f5b9ac'
   end
@@ -642,14 +651,5 @@ RSpec.describe ReadySet::Query do
 
   def seen_but_not_cached_query
     ReadySet::Query.new(seen_but_not_cached_query_attributes)
-  end
-
-  def expect_queries_to_be_equal(query1, query2)
-    query1.id == query2.id &&
-      query1.text == query2.text &&
-      query1.supported == query2.supported &&
-      query1.cache_name == query2.cache_name &&
-      query1.send(:fallback_behavior) == query2.send(:fallback_behavior) &&
-      query1.count == query2.count
   end
 end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe Readyset::Query do
   end
 
   describe '.cache_all_supported!' do
-    subject { ReadySet::Query.cache_all_supported!(always: true) }
+    subject { Readyset::Query.cache_all_supported!(always: true) }
 
     let(:queries) { supported_queries + unsupported_or_pending_queries }
     let(:supported_queries) do
       [
         seen_but_not_cached_query,
-        ReadySet::Query.new({
+        Readyset::Query.new({
           'query id' => 'q_8892818e62c34ecd',
           'proxied query' => 'SELECT * FROM "t" WHERE ("y" = $1)',
           'readyset supported' => 'yes',
@@ -62,13 +62,13 @@ RSpec.describe Readyset::Query do
     end
     let(:unsupported_or_pending_queries) do
       [
-        ReadySet::Query.new(
+        Readyset::Query.new(
           'query id' => 'q_f9bfc11a043b2f75',
           'proxied query' => 'SHOW TIME ZONE',
           'readyset supported' => 'unsupported',
           'count' => 5,
         ),
-        ReadySet::Query.new(
+        Readyset::Query.new(
           'query id' => 'q_d7cbfb8a03d589cf',
           'proxied query' => 'SELECT * FROM "t" WHERE ("x" < 1)',
           'readyset supported' => 'pending',
@@ -78,23 +78,23 @@ RSpec.describe Readyset::Query do
     end
 
     before do
-      allow(ReadySet::Query).to receive(:all_seen_but_not_cached).and_return(queries)
+      allow(Readyset::Query).to receive(:all_seen_but_not_cached).and_return(queries)
     end
 
-    context 'when every ReadySet::Query#cache! invocation succeeds' do
+    context 'when every Readyset::Query#cache! invocation succeeds' do
       before do
         queries.each { |query| allow(query).to receive(:cache!).with(always: true) }
         subject
       end
 
-      it 'invokes ReadySet::Query#cache! on every supported query with the given "always" ' \
+      it 'invokes Readyset::Query#cache! on every supported query with the given "always" ' \
         'parameter' do
         supported_queries.each do |query|
           expect(query).to have_received(:cache!).with(always: true)
         end
       end
 
-      it 'does not invoke ReadySet::Query#cache! on any unsupported or pending queries' do
+      it 'does not invoke Readyset::Query#cache! on any unsupported or pending queries' do
         unsupported_or_pending_queries.each do |query|
           expect(query).not_to have_received(:cache!)
         end
@@ -105,7 +105,7 @@ RSpec.describe Readyset::Query do
       end
     end
 
-    context 'when one of the ReadySet::Query#cache! invocations fails' do
+    context 'when one of the Readyset::Query#cache! invocations fails' do
       before do
         allow(queries[0]).to receive(:cache!).and_raise(StandardError)
         allow(queries[1]).to receive(:cache!)
@@ -117,16 +117,16 @@ RSpec.describe Readyset::Query do
         end
       end
 
-      it 'raises the error raised by the ReadySet::Query#cache! invocation' do
+      it 'raises the error raised by the Readyset::Query#cache! invocation' do
         expect { subject }.to raise_error(StandardError)
       end
 
-      it 'invokes ReadySet::Query#cache! on the queries in the list up to and including the ' \
+      it 'invokes Readyset::Query#cache! on the queries in the list up to and including the ' \
         'query that caused the error with the given "always" parameter' do
         expect(queries[0]).to have_received(:cache!).with(always: true)
       end
 
-      it 'does not invoke ReadySet::Query#cache! on any of the queries in the list after the ' \
+      it 'does not invoke Readyset::Query#cache! on any of the queries in the list after the ' \
         'query that caused the error' do
         expect(queries[1]).not_to have_received(:cache!)
       end
@@ -134,16 +134,16 @@ RSpec.describe Readyset::Query do
   end
 
   describe '.drop_all_caches!' do
-    subject { ReadySet::Query.drop_all_caches! }
+    subject { Readyset::Query.drop_all_caches! }
 
     before do
-      allow(ReadySet).to receive(:raw_query).with('DROP ALL CACHES')
+      allow(Readyset).to receive(:raw_query).with('DROP ALL CACHES')
 
       subject
     end
 
-    it 'invokes "DROP ALL CACHES" against ReadySet' do
-      expect(ReadySet).to have_received(:raw_query).with('DROP ALL CACHES')
+    it 'invokes "DROP ALL CACHES" against Readyset' do
+      expect(Readyset).to have_received(:raw_query).with('DROP ALL CACHES')
     end
 
     it 'returns nil' do
@@ -376,8 +376,8 @@ RSpec.describe Readyset::Query do
 
       let(:query) { cached_query }
 
-      it 'raises a ReadySet::Query::CacheAlreadyExistsError' do
-        expect { subject }.to raise_error(ReadySet::Query::CacheAlreadyExistsError)
+      it 'raises a Readyset::Query::CacheAlreadyExistsError' do
+        expect { subject }.to raise_error(Readyset::Query::CacheAlreadyExistsError)
       end
     end
 
@@ -385,7 +385,7 @@ RSpec.describe Readyset::Query do
       subject { query.cache! }
 
       let(:query) do
-        ReadySet::Query.new(
+        Readyset::Query.new(
           'query id' => 'q_f9bfc11a043b2f75',
           'proxied query' => 'SHOW TIME ZONE',
           'readyset supported' => 'unsupported',
@@ -393,8 +393,8 @@ RSpec.describe Readyset::Query do
         )
       end
 
-      it 'raises a ReadySet::Query::UnsupportedError' do
-        expect { subject }.to raise_error(ReadySet::Query::UnsupportedError)
+      it 'raises a Readyset::Query::UnsupportedError' do
+        expect { subject }.to raise_error(Readyset::Query::UnsupportedError)
       end
     end
 
@@ -402,7 +402,7 @@ RSpec.describe Readyset::Query do
       let(:query) { seen_but_not_cached_query }
 
       before do
-        allow(ReadySet).to receive(:raw_query).with(*create_cache_statement)
+        allow(Readyset).to receive(:raw_query).with(*create_cache_statement)
         allow(query).to receive(:reload)
 
         subject
@@ -413,11 +413,11 @@ RSpec.describe Readyset::Query do
 
         let(:create_cache_statement) { ['CREATE CACHE ALWAYS FROM %s', query_id] }
 
-        it 'invokes "CREATE CACHE ALWAYS FROM <query_id>" on ReadySet' do
-          expect(ReadySet).to have_received(:raw_query).with(*create_cache_statement)
+        it 'invokes "CREATE CACHE ALWAYS FROM <query_id>" on Readyset' do
+          expect(Readyset).to have_received(:raw_query).with(*create_cache_statement)
         end
 
-        it 'invokes ReadySet::Query#reload' do
+        it 'invokes Readyset::Query#reload' do
           expect(query).to have_received(:reload)
         end
 
@@ -432,8 +432,8 @@ RSpec.describe Readyset::Query do
         let(:create_cache_statement) { ['CREATE CACHE ? FROM %s', name, query_id] }
         let(:name) { 'test cache' }
 
-        it 'invokes "CREATE CACHE <name> FROM <query_id>" on ReadySet' do
-          expect(ReadySet).to have_received(:raw_query).with(*create_cache_statement)
+        it 'invokes "CREATE CACHE <name> FROM <query_id>" on Readyset' do
+          expect(Readyset).to have_received(:raw_query).with(*create_cache_statement)
         end
 
         it 'invokes Query#reload' do
@@ -451,8 +451,8 @@ RSpec.describe Readyset::Query do
         let(:create_cache_statement) { ['CREATE CACHE ALWAYS ? FROM %s', name, query_id] }
         let(:name) { 'test cache' }
 
-        it 'invokes "CREATE CACHE ALWAYS <name> FROM <query_id>" on ReadySet' do
-          expect(ReadySet).to have_received(:raw_query).with(*create_cache_statement)
+        it 'invokes "CREATE CACHE ALWAYS <name> FROM <query_id>" on Readyset' do
+          expect(Readyset).to have_received(:raw_query).with(*create_cache_statement)
         end
 
         it 'invokes Query#reload' do
@@ -465,8 +465,8 @@ RSpec.describe Readyset::Query do
 
         let(:create_cache_statement) { ['CREATE CACHE FROM %s', query_id] }
 
-        it 'invokes "CREATE CACHE FROM <query_id>" on ReadySet' do
-          expect(ReadySet).to have_received(:raw_query).with(*create_cache_statement)
+        it 'invokes "CREATE CACHE FROM <query_id>" on Readyset' do
+          expect(Readyset).to have_received(:raw_query).with(*create_cache_statement)
         end
 
         it 'invokes Query#reload' do
@@ -505,17 +505,17 @@ RSpec.describe Readyset::Query do
       let(:query) { cached_query }
 
       before do
-        allow(ReadySet).to receive(:raw_query).with('DROP CACHE %s', query_id)
+        allow(Readyset).to receive(:raw_query).with('DROP CACHE %s', query_id)
         allow(query).to receive(:reload)
 
         subject
       end
 
-      it 'invokes "DROP CACHE <query_id> on ReadySet' do
-        expect(ReadySet).to have_received(:raw_query).with('DROP CACHE %s', query_id)
+      it 'invokes "DROP CACHE <query_id> on Readyset' do
+        expect(Readyset).to have_received(:raw_query).with('DROP CACHE %s', query_id)
       end
 
-      it 'invokes ReadySet::Query#reload' do
+      it 'invokes Readyset::Query#reload' do
         expect(query).to have_received(:reload)
       end
 
@@ -527,8 +527,8 @@ RSpec.describe Readyset::Query do
     context 'when the query is not cached' do
       let(:query) { seen_but_not_cached_query }
 
-      it 'raises a ReadySet::Query::NotCachedError' do
-        expect { subject }.to raise_error(ReadySet::Query::NotCachedError)
+      it 'raises a Readyset::Query::NotCachedError' do
+        expect { subject }.to raise_error(Readyset::Query::NotCachedError)
       end
     end
   end
@@ -624,7 +624,7 @@ RSpec.describe Readyset::Query do
   end
 
   def cached_query
-    ReadySet::Query.new(cached_query_attributes)
+    Readyset::Query.new(cached_query_attributes)
   end
 
   def expect_queries_to_be_equal(query1, query2)
@@ -650,6 +650,6 @@ RSpec.describe Readyset::Query do
   end
 
   def seen_but_not_cached_query
-    ReadySet::Query.new(seen_but_not_cached_query_attributes)
+    Readyset::Query.new(seen_but_not_cached_query_attributes)
   end
 end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -16,4 +16,4 @@ RSpec.shared_examples 'a wrapper around a ReadySet SQL extension' do |sql_comman
   it 'returns the expected result' do
     expect(subject).to eq(expected_output)
   end
-end 
+end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -1,0 +1,19 @@
+RSpec.shared_examples 'a wrapper around a ReadySet SQL extension' do |sql_command|
+  let(:args) { [] }
+  let(:expected_output) { nil }
+  let(:raw_query_result) { nil }
+
+  before do
+    allow(Readyset).to receive(:raw_query).with(sql_command, *args).and_return(raw_query_result)
+
+    subject
+  end
+
+  it "invokes \"#{sql_command}\" on ReadySet" do
+    expect(Readyset).to have_received(:raw_query).with(sql_command, *args)
+  end
+
+  it 'returns the expected result' do
+    expect(subject).to eq(expected_output)
+  end
+end 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,9 @@
 require 'bundler/setup'
 Bundler.setup
 
+require 'factory_bot'
 require 'readyset'
+require_relative 'shared_examples'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -14,5 +16,10 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.include FactoryBot::Syntax::Methods
+  config.before(:suite) do
+    FactoryBot.find_definitions
   end
 end


### PR DESCRIPTION
This commit adds methods to:
- Cache a given query
- Drop the cache for a given query
- Cache all supported queries
- Drop all caches