### PR TITLE
gemspec: Remove Rails dependency

### DIFF
--- a/readyset.gemspec
+++ b/readyset.gemspec
@@ -31,7 +31,9 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails', '~> 6.1'
+  spec.add_dependency 'actionpack', '>= 6.1'
+  spec.add_dependency 'activerecord', '>= 6.1'
+  spec.add_dependency 'activesupport', '>= 6.1'
   spec.add_dependency 'rake', '~> 13.0'
 
   spec.add_development_dependency 'rspec', '~> 3.2'


### PR DESCRIPTION
This commit removes the dependency on the rails gem and replaces it with only the subdependencies we use: actionpack, activerecord, and activesupport.