### PR TITLE
docs: Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[bug]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,29 +10,22 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+**To Reproduce**:
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+**Expected behavior**:
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
-
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**System Configuration**: 
+Your environment and set-up in which the problem occurred. 
+1. Ruby version
+2. Rails version
+3. OS
+4. Logs
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,35 @@
+---
+name: Feature request
+about: Suggest an improvement for this project
+title: "[feature]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Brief Description of Feature:**
+[Provide a concise description of the feature you want to add.]
+
+**Background:**
+[Include any relevant background information or context that led to this feature request.]
+
+**Detailed Explanation:**
+[Provide a detailed explanation of the feature, including how it should work and its expected behavior. Mention any specific changes to the current workflow or user experience.]
+
+**Problem Statement:**
+[Clearly articulate the problem that this feature will solve. Reference any specific issues or limitations in the current implementation of the Ruby gem that this feature addresses.]
+
+**Proposed Solution:**
+[Describe your proposed solution, including technical details, if applicable. Multiple ideas are okay too. Or just roughly describe what a successful implementation would look like.]
+
+**Benefits / Pros:**
+[List the benefits of implementing this feature. Explain how it will improve the user experience, performance, or functionality of the Ruby gem.]
+
+**Potential Drawbacks / Cons:**
+[Discuss any potential drawbacks or negative impacts of the proposed feature.]
+
+**Alternative Approaches Considered:**
+[If you have considered alternative solutions or enhancements that are not part of this request, briefly describe them here.]
+
+**Additional Context:**
+[Provide any additional information, such as examples, mock-ups, or use cases, to help understand the feature request. This is a catch-all section for any info that doesn't fit in the other categories.]


### PR DESCRIPTION
New feature request and bug report templates for Github issues. 

The feature request was based off the structure of Ethan's Google Doc describing a problem and a proposed solution. 

The abstract from said doc: 
The way we are currently thinking about our Ruby gem makes for a confusing user experience due to the query status cache and due to the fact that annotating a method or class doesn’t actually give us a list of  queries to cache at application startup. It may make sense to pursue an alternative approach where users specify specific queries to cache up front
