### PR TITLE
treewide: Rename `ReadySet` to `Readyset`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 TODO: Delete this and the text below, and describe your gem
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/ready_set`. To experiment with that code, run `bin/console` for an interactive prompt.
+Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/readyset`. To experiment with that code, run `bin/console` for an interactive prompt.
 
 ## Installation
 

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'ready_set'
+require 'readyset'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/readyset.rb
+++ b/lib/readyset.rb
@@ -1,14 +1,14 @@
-# lib/ready_set.rb
+# lib/readyset.rb
 
-require 'ready_set/configuration'
-require 'ready_set/default_resolver'
-require 'ready_set/middleware'
-require 'ready_set/query'
-require 'ready_set/railtie' if defined?(Rails::Railtie)
+require 'readyset/configuration'
+require 'readyset/default_resolver'
+require 'readyset/middleware'
+require 'readyset/query'
+require 'readyset/railtie' if defined?(Rails::Railtie)
 
 require 'active_record'
 
-module ReadySet
+module Readyset
   attr_writer :configuration
 
   def self.configuration
@@ -28,7 +28,7 @@ module ReadySet
   # @param [Array<Object>] *sql_array the SQL array to be executed against ReadySet
   # @return [PG::Result]
   def self.raw_query(*sql_array)
-    ActiveRecord::Base.establish_connection(ReadySet.configuration.connection_url)
+    ActiveRecord::Base.establish_connection(Readyset.configuration.connection_url)
     ActiveRecord::Base.connection.execute(ActiveRecord::Base.sanitize_sql_array(sql_array))
   end
 end

--- a/lib/readyset/configuration.rb
+++ b/lib/readyset/configuration.rb
@@ -1,6 +1,6 @@
-# lib/ready_set/configuration.rb
+# lib/readyset/configuration.rb
 
-module ReadySet
+module Readyset
   class Configuration
     attr_accessor :connection_url, :database_selector, :database_resolver,
       :database_resolver_context
@@ -8,7 +8,7 @@ module ReadySet
     def initialize
       @connection_url = ENV['READYSET_URL'] || default_connection_url
       @database_selector = { delay: 2.seconds }
-      @database_resolver = ReadySet::DefaultResolver
+      @database_resolver = Readyset::DefaultResolver
       @database_resolver_context = nil
     end
 

--- a/lib/readyset/default_resolver.rb
+++ b/lib/readyset/default_resolver.rb
@@ -1,8 +1,8 @@
-# lib/ready_set/default_resolver.rb
+# lib/readyset/default_resolver.rb
 
 require 'active_record'
 
-module ReadySet
+module Readyset
   class DefaultResolver < ActiveRecord::Middleware::DatabaseSelector::Resolver
     def read_from_replica?(session, &block)
       # TODO: Implement good defaults for resolving requests

--- a/lib/readyset/middleware.rb
+++ b/lib/readyset/middleware.rb
@@ -1,17 +1,17 @@
-# lib/ready_set/middleware.rb
+# lib/readyset/middleware.rb
 
 # Mentioned in the docs:
 # The core time extension is necessary for the default 2-second delay
 require 'active_support/core_ext/integer/time'
 require 'action_dispatch'
 
-module ReadySet
+module Readyset
   class Middleware
     def initialize(app)
       @app = app
-      @resolver_klass = ReadySet.configuration.database_resolver ||
+      @resolver_klass = Readyset.configuration.database_resolver ||
         ActiveRecord::Middleware::DatabaseSelector::Resolver
-      @context_klass = ReadySet.configuration.database_resolver_context ||
+      @context_klass = Readyset.configuration.database_resolver_context ||
         ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
     end
 

--- a/lib/readyset/query.rb
+++ b/lib/readyset/query.rb
@@ -1,13 +1,13 @@
-# lib/ready_set/query.rb
+# lib/readyset/query.rb
 
 require 'active_model'
 
-module ReadySet
+module Readyset
   # Represents a query that has been seen by ReadySet. This query may be cached or uncached.
   class Query
     include ActiveModel::AttributeMethods
 
-    # An error raised when a `ReadySet::Query` is expected to be cached but isn't.
+    # An error raised when a `Readyset::Query` is expected to be cached but isn't.
     class NotCachedError < StandardError
       attr_reader :id
 
@@ -20,7 +20,7 @@ module ReadySet
       end
     end
 
-    # An error raised when a `ReadySet::Query` with the given ID can't be found on the ReadySet
+    # An error raised when a `Readyset::Query` with the given ID can't be found on the ReadySet
     # instance.
     class NotFoundError < StandardError
       attr_reader :id
@@ -39,25 +39,25 @@ module ReadySet
     # Returns all of the queries currently cached on ReadySet by invoking the `SHOW CACHES` SQL
     # extension on ReadySet.
     #
-    # @return [Array<ReadySet::Query>]
+    # @return [Array<Readyset::Query>]
     def self.all_cached
-      ReadySet.raw_query('SHOW CACHES').map { |result| new(result) }
+      Readyset.raw_query('SHOW CACHES').map { |result| new(result) }
     end
 
     # Returns all of the queries seen by ReadySet that are not currently cached. This list is
     # retrieved by invoking the `SHOW PROXIED QUERIES` SQL extension on ReadySet.
     #
-    # @return [Array<ReadySet::Query>]
+    # @return [Array<Readyset::Query>]
     def self.all_seen_but_not_cached
-      ReadySet.raw_query('SHOW PROXIED QUERIES').map { |result| new(result) }
+      Readyset.raw_query('SHOW PROXIED QUERIES').map { |result| new(result) }
     end
 
     # Finds the query with the given query ID by directly querying ReadySet. If a query with the
-    # given ID doesn't exist, this method raises a `ReadySet::Query::NotFoundError`.
+    # given ID doesn't exist, this method raises a `Readyset::Query::NotFoundError`.
     #
     # @param [String] id the ID of the query to be searched for
     # @return [Query]
-    # @raise [ReadySet::Query::NotFoundError] raised if a query with the given ID cannot be found
+    # @raise [Readyset::Query::NotFoundError] raised if a query with the given ID cannot be found
     def self.find(id)
       find_seen_but_not_cached(id)
     rescue NotFoundError
@@ -65,11 +65,11 @@ module ReadySet
     end
 
     # Returns the cached query with the given query ID by directly querying ReadySet. If a cached
-    # query with the given ID doesn't exist, this method raises a `ReadySet::Query::NotFoundError`.
+    # query with the given ID doesn't exist, this method raises a `Readyset::Query::NotFoundError`.
     #
     # @param [String] id the ID of the query to be searched for
     # @return [Query]
-    # @raise [ReadySet::Query::NotFoundError] raised if a cached query with the given ID cannot be
+    # @raise [Readyset::Query::NotFoundError] raised if a cached query with the given ID cannot be
     # found
     def self.find_cached(id)
       find_inner('SHOW CACHES WHERE query_id = ?', id)
@@ -77,21 +77,21 @@ module ReadySet
 
     # Returns the query with the given query ID that has been seen by ReadySet but is not cached.
     # The query is searched for by directly querying ReadySet. If a seen-but-not-cached query with
-    # the given ID doesn't exist, this method raises a `ReadySet::Query::NotFoundError`.
+    # the given ID doesn't exist, this method raises a `Readyset::Query::NotFoundError`.
     #
     # @param [String] id the ID of the query to be searched for
     # @return [Query]
-    # @raise [ReadySet::Query::NotFoundError] raised if a seen-but-not-cached query with the given
+    # @raise [Readyset::Query::NotFoundError] raised if a seen-but-not-cached query with the given
     # ID cannot be found
     def self.find_seen_but_not_cached(id)
       find_inner('SHOW PROXIED QUERIES WHERE query_id = ?', id)
     end
 
-    # Constructs a new `ReadySet::Query` from the given hash. The keys of this hash should
+    # Constructs a new `Readyset::Query` from the given hash. The keys of this hash should
     # correspond to the columns in the results returned by the `SHOW PROXIED QUERIES` and
     # `SHOW CACHES` ReadySet SQL extensions.
     #
-    # @param [Hash] attributes the attributes from which the `ReadySet::Query` should be
+    # @param [Hash] attributes the attributes from which the `Readyset::Query` should be
     # constructed
     # @return [Query]
     def initialize(attributes)
@@ -112,10 +112,10 @@ module ReadySet
 
     # Returns true if the cached query supports falling back to the upstream database and false
     # otherwise. If the query is not cached, this method raises a
-    # `ReadySet::Query::NotCachedError`.
+    # `Readyset::Query::NotCachedError`.
     #
     # @return [Boolean]
-    # @raise [ReadySet::Query::NotCachedError]
+    # @raise [Readyset::Query::NotCachedError]
     def fallback_allowed?
       if cached?
         @fallback_behavior == 'fallback allowed'.to_sym
@@ -147,7 +147,7 @@ module ReadySet
     private
 
     def self.find_inner(query, id)
-      result = ReadySet.raw_query(query, id).first
+      result = Readyset.raw_query(query, id).first
 
       if result.nil?
         raise NotFoundError, id

--- a/lib/readyset/rails/version.rb
+++ b/lib/readyset/rails/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ReadySet
+module Readyset
   module Rails
     VERSION = '0.1.0'
   end

--- a/lib/readyset/railtie.rb
+++ b/lib/readyset/railtie.rb
@@ -1,9 +1,9 @@
-# lib/ready_set/railtie.rb
+# lib/readyset/railtie.rb
 
-module ReadySet
+module Readyset
   class Railtie < Rails::Railtie
     initializer 'readyset.configure_rails_initialization' do |app|
-      app.middleware.use ReadySet::Middleware
+      app.middleware.use Readyset::Middleware
     end
   end
 end

--- a/lib/readyset/version.rb
+++ b/lib/readyset/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module ReadySet
+module Readyset
   VERSION = '0.1.0'
 end

--- a/readyset.gemspec
+++ b/readyset.gemspec
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require_relative 'lib/ready_set/version'
+require_relative 'lib/readyset/version'
 
 Gem::Specification.new do |spec|
   spec.name = 'readyset'
-  spec.version = ReadySet::VERSION
+  spec.version = Readyset::VERSION
   spec.authors = ['ReadySet Technology, Inc.']
   spec.email = ['info@readyset.io']
 

--- a/sig/readyset.rbs
+++ b/sig/readyset.rbs
@@ -1,4 +1,4 @@
-module ReadySet
+module Readyset
   VERSION: String
   # See the writing guide of rbs: https://github.com/ruby/rbs#guides
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -2,19 +2,19 @@
 # spec/readyset-rails/configuration_spec.rb
 
 require 'spec_helper'
-require_relative './../lib/ready_set/configuration.rb'
+require_relative './../lib/readyset/configuration.rb'
 
-RSpec.describe ReadySet::Configuration do
+RSpec.describe Readyset::Configuration do
   let(:config) { described_class.new }
 
   describe '#initialize' do
     it 'sets default values' do
-      config = ReadySet::Configuration.new
+      config = Readyset::Configuration.new
 
       expect(config.connection_url).
         to eq(ENV['READYSET_URL'] || 'postgres://user:password@localhost:5432/readyset')
       expect(config.database_selector).to eq({ delay: 2.seconds })
-      expect(config.database_resolver).to eq(ReadySet::DefaultResolver)
+      expect(config.database_resolver).to eq(Readyset::DefaultResolver)
       expect(config.database_resolver_context).to be_nil
     end
   end

--- a/spec/default_resolver_spec.rb
+++ b/spec/default_resolver_spec.rb
@@ -2,11 +2,11 @@
 # spec/readyset/default_resolver_spec.rb
 
 require 'spec_helper'
-require_relative './../lib/ready_set/default_resolver'
+require_relative './../lib/readyset/default_resolver'
 
-RSpec.describe ReadySet::DefaultResolver do
+RSpec.describe Readyset::DefaultResolver do
   describe '#read_from_replica?' do
-    let(:resolver) { ReadySet::DefaultResolver.new({ delay: 2.seconds }) }
+    let(:resolver) { Readyset::DefaultResolver.new({ delay: 2.seconds }) }
 
     it 'returns true by default' do
       expect(resolver.read_from_replica?(nil)).to be true

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -2,12 +2,12 @@
 # spec/readyset/middleware_spec.rb
 
 require 'spec_helper'
-require_relative './../lib/ready_set/middleware'
+require_relative './../lib/readyset/middleware'
 
-RSpec.describe ReadySet::Middleware do
+RSpec.describe Readyset::Middleware do
   let(:app) { double('App', call: true) }
   let(:env) { {} }
-  let(:middleware) { ReadySet::Middleware.new(app) }
+  let(:middleware) { Readyset::Middleware.new(app) }
 
   it 'initializes with an app' do
     expect(middleware.instance_variable_get(:@app)).to eq(app)

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -2,9 +2,9 @@
 
 # require 'spec_helper'
 
-RSpec.describe ReadySet::Query do
+RSpec.describe Readyset::Query do
   describe '.all_cached' do
-    subject { ReadySet::Query.all_cached }
+    subject { Readyset::Query.all_cached }
 
     let(:cached_queries) do
       [
@@ -19,12 +19,12 @@ RSpec.describe ReadySet::Query do
     end
 
     before do
-      allow(ReadySet).to receive(:raw_query).with('SHOW CACHES').and_return(cached_queries)
+      allow(Readyset).to receive(:raw_query).with('SHOW CACHES').and_return(cached_queries)
       subject
     end
 
-    it 'invokes "SHOW CACHES" on ReadySet' do
-      expect(ReadySet).to have_received(:raw_query).with('SHOW CACHES')
+    it 'invokes "SHOW CACHES" on Readyset' do
+      expect(Readyset).to have_received(:raw_query).with('SHOW CACHES')
     end
 
     it 'returns the cached queries' do
@@ -37,7 +37,7 @@ RSpec.describe ReadySet::Query do
   end
 
   describe '.all_seen_but_not_cached' do
-    subject { ReadySet::Query.all_seen_but_not_cached }
+    subject { Readyset::Query.all_seen_but_not_cached }
 
     let(:seen_but_not_cached_queries) do
       [
@@ -51,14 +51,14 @@ RSpec.describe ReadySet::Query do
     end
 
     before do
-      allow(ReadySet).to receive(:raw_query).with('SHOW PROXIED QUERIES').
+      allow(Readyset).to receive(:raw_query).with('SHOW PROXIED QUERIES').
         and_return(seen_but_not_cached_queries)
 
       subject
     end
 
-    it 'invokes "SHOW PROXIED QUERIES" on ReadySet' do
-      expect(ReadySet).to have_received(:raw_query).with('SHOW PROXIED QUERIES')
+    it 'invokes "SHOW PROXIED QUERIES" on Readyset' do
+      expect(Readyset).to have_received(:raw_query).with('SHOW PROXIED QUERIES')
     end
 
     it 'returns the seen-but-not-cached queries' do
@@ -71,7 +71,7 @@ RSpec.describe ReadySet::Query do
   end
 
   describe '.find' do
-    subject { ReadySet::Query.find(query_id) }
+    subject { Readyset::Query.find(query_id) }
 
     let(:query_id) { 'q_eafb620c78f5b9ac' }
 
@@ -87,12 +87,12 @@ RSpec.describe ReadySet::Query do
       end
 
       before do
-        allow(ReadySet).
+        allow(Readyset).
           to receive(:raw_query).
           with('SHOW PROXIED QUERIES WHERE query_id = ?', query_id).
-          and_raise(ReadySet::Query::NotFoundError.new(query_id))
+          and_raise(Readyset::Query::NotFoundError.new(query_id))
 
-        allow(ReadySet).
+        allow(Readyset).
           to receive(:raw_query).
           with('SHOW CACHES WHERE query_id = ?', query_id).
           and_return([query])
@@ -100,14 +100,14 @@ RSpec.describe ReadySet::Query do
         subject
       end
 
-      it 'invokes "SHOW PROXIED QUERIES" on ReadySet' do
-        expect(ReadySet).
+      it 'invokes "SHOW PROXIED QUERIES" on Readyset' do
+        expect(Readyset).
           to have_received(:raw_query).
           with('SHOW PROXIED QUERIES WHERE query_id = ?', query_id)
       end
 
-      it 'invokes "SHOW CACHES" on ReadySet' do
-        expect(ReadySet).
+      it 'invokes "SHOW CACHES" on Readyset' do
+        expect(Readyset).
           to have_received(:raw_query).
           with('SHOW CACHES WHERE query_id = ?', query_id)
       end
@@ -132,7 +132,7 @@ RSpec.describe ReadySet::Query do
       end
 
       before do
-        allow(ReadySet).
+        allow(Readyset).
           to receive(:raw_query).
           with('SHOW PROXIED QUERIES WHERE query_id = ?', query_id).
           and_return([query])
@@ -140,8 +140,8 @@ RSpec.describe ReadySet::Query do
         subject
       end
 
-      it 'invokes "SHOW PROXIED QUERIES" on ReadySet' do
-        expect(ReadySet).
+      it 'invokes "SHOW PROXIED QUERIES" on Readyset' do
+        expect(Readyset).
           to have_received(:raw_query).
           with('SHOW PROXIED QUERIES WHERE query_id = ?', query_id)
       end
@@ -157,43 +157,43 @@ RSpec.describe ReadySet::Query do
 
     context 'when no query with the given ID exists' do
       before do
-        allow(ReadySet).
+        allow(Readyset).
           to receive(:raw_query).
           with('SHOW PROXIED QUERIES WHERE query_id = ?', query_id).
-          and_raise(ReadySet::Query::NotFoundError.new(query_id))
+          and_raise(Readyset::Query::NotFoundError.new(query_id))
 
-        allow(ReadySet).
+        allow(Readyset).
           to receive(:raw_query).
           with('SHOW CACHES WHERE query_id = ?', query_id).
-          and_raise(ReadySet::Query::NotFoundError.new(query_id))
+          and_raise(Readyset::Query::NotFoundError.new(query_id))
 
         begin
           subject
-        rescue ReadySet::Query::NotFoundError
+        rescue Readyset::Query::NotFoundError
           nil
         end
       end
 
-      it 'invokes "SHOW PROXIED QUERIES" on ReadySet' do
-        expect(ReadySet).
+      it 'invokes "SHOW PROXIED QUERIES" on Readyset' do
+        expect(Readyset).
           to have_received(:raw_query).
           with('SHOW PROXIED QUERIES WHERE query_id = ?', query_id)
       end
 
-      it 'invokes "SHOW CACHES" on ReadySet' do
-        expect(ReadySet).
+      it 'invokes "SHOW CACHES" on Readyset' do
+        expect(Readyset).
           to have_received(:raw_query).
           with('SHOW CACHES WHERE query_id = ?', query_id)
       end
 
-      it 'raises a ReadySet::Query::NotFoundError' do
-        expect { subject }.to raise_error(ReadySet::Query::NotFoundError)
+      it 'raises a Readyset::Query::NotFoundError' do
+        expect { subject }.to raise_error(Readyset::Query::NotFoundError)
       end
     end
   end
 
   describe '.find_cached' do
-    subject { ReadySet::Query.find_cached(query_id) }
+    subject { Readyset::Query.find_cached(query_id) }
 
     let(:query_id) { 'q_eafb620c78f5b9ac' }
 
@@ -209,7 +209,7 @@ RSpec.describe ReadySet::Query do
       end
 
       before do
-        allow(ReadySet).
+        allow(Readyset).
           to receive(:raw_query).
           with('SHOW CACHES WHERE query_id = ?', query_id).
           and_return([query])
@@ -217,8 +217,8 @@ RSpec.describe ReadySet::Query do
         subject
       end
 
-      it 'invokes "SHOW CACHES" on ReadySet' do
-        expect(ReadySet).
+      it 'invokes "SHOW CACHES" on Readyset' do
+        expect(Readyset).
           to have_received(:raw_query).
           with('SHOW CACHES WHERE query_id = ?', query_id)
       end
@@ -234,32 +234,32 @@ RSpec.describe ReadySet::Query do
 
     context 'when a cached query with the given ID does not exist' do
       before do
-        allow(ReadySet).
+        allow(Readyset).
           to receive(:raw_query).
           with('SHOW CACHES WHERE query_id = ?', query_id).
-          and_raise(ReadySet::Query::NotFoundError.new(query_id))
+          and_raise(Readyset::Query::NotFoundError.new(query_id))
 
         begin
           subject
-        rescue ReadySet::Query::NotFoundError
+        rescue Readyset::Query::NotFoundError
           nil
         end
       end
 
-      it 'invokes "SHOW CACHES" on ReadySet' do
-        expect(ReadySet).
+      it 'invokes "SHOW CACHES" on Readyset' do
+        expect(Readyset).
           to have_received(:raw_query).
           with('SHOW CACHES WHERE query_id = ?', query_id)
       end
 
-      it 'raises a ReadySet::Query::NotFoundError' do
-        expect { subject }.to raise_error(ReadySet::Query::NotFoundError)
+      it 'raises a Readyset::Query::NotFoundError' do
+        expect { subject }.to raise_error(Readyset::Query::NotFoundError)
       end
     end
   end
 
   describe '.find_seen_but_not_cached' do
-    subject { ReadySet::Query.find_seen_but_not_cached(query_id) }
+    subject { Readyset::Query.find_seen_but_not_cached(query_id) }
 
     let(:query_id) { 'q_eafb620c78f5b9ac' }
 
@@ -274,7 +274,7 @@ RSpec.describe ReadySet::Query do
       end
 
       before do
-        allow(ReadySet).
+        allow(Readyset).
           to receive(:raw_query).
           with('SHOW PROXIED QUERIES WHERE query_id = ?', query_id).
           and_return([query])
@@ -282,8 +282,8 @@ RSpec.describe ReadySet::Query do
         subject
       end
 
-      it 'invokes "SHOW PROXIED QUERIES" on ReadySet' do
-        expect(ReadySet).
+      it 'invokes "SHOW PROXIED QUERIES" on Readyset' do
+        expect(Readyset).
           to have_received(:raw_query).
           with('SHOW PROXIED QUERIES WHERE query_id = ?', query_id)
       end
@@ -299,32 +299,32 @@ RSpec.describe ReadySet::Query do
 
     context 'when a seen-but-not-cached query with the given ID does not exist' do
       before do
-        allow(ReadySet).
+        allow(Readyset).
           to receive(:raw_query).
           with('SHOW PROXIED QUERIES WHERE query_id = ?', query_id).
-          and_raise(ReadySet::Query::NotFoundError.new(query_id))
+          and_raise(Readyset::Query::NotFoundError.new(query_id))
 
         begin
           subject
-        rescue ReadySet::Query::NotFoundError
+        rescue Readyset::Query::NotFoundError
           nil
         end
       end
 
-      it 'invokes "SHOW PROXIED QUERIES" on ReadySet' do
-        expect(ReadySet).
+      it 'invokes "SHOW PROXIED QUERIES" on Readyset' do
+        expect(Readyset).
           to have_received(:raw_query).
           with('SHOW PROXIED QUERIES WHERE query_id = ?', query_id)
       end
 
-      it 'raises a ReadySet::Query::NotFoundError' do
-        expect { subject }.to raise_error(ReadySet::Query::NotFoundError)
+      it 'raises a Readyset::Query::NotFoundError' do
+        expect { subject }.to raise_error(Readyset::Query::NotFoundError)
       end
     end
   end
 
   describe '.new' do
-    subject { ReadySet::Query.new(attrs) }
+    subject { Readyset::Query.new(attrs) }
 
     context 'when given the attributes from a cached query' do
       let(:attrs) do
@@ -377,7 +377,7 @@ RSpec.describe ReadySet::Query do
           'count' => 5,
         }
 
-        ReadySet::Query.new(attrs)
+        Readyset::Query.new(attrs)
       end
 
       it 'returns true' do
@@ -394,7 +394,7 @@ RSpec.describe ReadySet::Query do
           'count' => 5,
         }
 
-        ReadySet::Query.new(attrs)
+        Readyset::Query.new(attrs)
       end
 
       it 'returns false' do
@@ -404,7 +404,7 @@ RSpec.describe ReadySet::Query do
   end
 
   describe '#fallback_allowed?' do
-    subject { ReadySet::Query.new(attrs).fallback_allowed? }
+    subject { Readyset::Query.new(attrs).fallback_allowed? }
 
     context 'when the query is not cached' do
       let(:attrs) do
@@ -416,8 +416,8 @@ RSpec.describe ReadySet::Query do
         }
       end
 
-      it 'raises a ReadySet::Query::NotCachedError' do
-        expect { subject }.to raise_error(ReadySet::Query::NotCachedError)
+      it 'raises a Readyset::Query::NotCachedError' do
+        expect { subject }.to raise_error(Readyset::Query::NotCachedError)
       end
     end
 
@@ -467,7 +467,7 @@ RSpec.describe ReadySet::Query do
         'count' => 5,
       }
 
-      ReadySet::Query.new(attrs)
+      Readyset::Query.new(attrs)
     end
 
     let(:query_id) { 'q_eafb620c78f5b9ac' }
@@ -480,14 +480,14 @@ RSpec.describe ReadySet::Query do
         'fallback behavior' => 'fallback allowed',
         'count' => 0,
       }
-      updated_query = ReadySet::Query.new(attrs)
+      updated_query = Readyset::Query.new(attrs)
 
-      allow(ReadySet::Query).to receive(:find).with(query_id).and_return(updated_query)
+      allow(Readyset::Query).to receive(:find).with(query_id).and_return(updated_query)
 
       subject
     end
 
-    it 'updates the attributes of the query with updated data from ReadySet' do
+    it 'updates the attributes of the query with updated data from Readyset' do
       expect(query.id).to eq(query_id)
       expect(query.supported).to eq(:yes)
       expect(query.cache_name).to eq(query_id)

--- a/spec/ready_set_spec.rb
+++ b/spec/ready_set_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-RSpec.describe ReadySet do
+RSpec.describe Readyset do
   it 'has a version number' do
-    expect(ReadySet::VERSION).not_to be nil
+    expect(Readyset::VERSION).not_to be nil
   end
 
   describe '.raw_query' do
-    subject { ReadySet.raw_query(*query) }
+    subject { Readyset.raw_query(*query) }
 
     let(:connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
     let(:connection_url) { 'postgres://postgres:readyset@127.0.0.1:5432/test' }
@@ -15,7 +15,7 @@ RSpec.describe ReadySet do
     let(:sanitized_query) { 'SELECT * FROM t WHERE x = 0' }
 
     before do
-      ReadySet.configuration.connection_url = connection_url
+      Readyset.configuration.connection_url = connection_url
 
       allow(ActiveRecord::Base).to receive(:establish_connection).with(connection_url)
       allow(ActiveRecord::Base).to receive(:connection).and_return(connection)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require 'bundler/setup'
 Bundler.setup
 
-require 'ready_set'
+require 'readyset'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Originally, we thought it would make more sense to name our primary module `ReadySet`, since that is how the word "ReadySet" is stylized elsewhere. However, this forced us to change the name of `lib/readyset`/`lib/readyset.rb` to `lib/ready_set`/`lib/ready_set.rb`. Because the name of our gem is "readyset" (and not "ready_set"), this broke Rails's autoloading feature, which meant users had to add `require: 'ready_set'` in their Gemspec to get our gem loaded correctly.

Given all of this, this commit changes the name of the `ReadySet` module back to `Readyset`, which allows us to keep our gem named "readyset" while still allowing autoloading to take place.