### PR TITLE
Allow users to define ReadySet "query methods" via new `readyset_query` syntax

### DIFF
--- a/lib/readyset.rb
+++ b/lib/readyset.rb
@@ -2,6 +2,7 @@
 
 require 'readyset/configuration'
 require 'readyset/controller_extension'
+require 'readyset/model_extension'
 require 'readyset/query'
 require 'readyset/railtie' if defined?(Rails::Railtie)
 require 'readyset/relation_extension'

--- a/lib/readyset/model_extension.rb
+++ b/lib/readyset/model_extension.rb
@@ -1,0 +1,40 @@
+module Readyset
+  module ModelExtension
+    extend ActiveSupport::Concern
+
+    prepended do
+      require 'active_support'
+
+      # Defines a new class method on a model that wraps the ActiveRecord query in `body` in a call
+      # to `Readyset.route`.
+      #
+      # NOTE: `body` should consist of nothing other than an ActiveRecord query! If you need to run
+      # actions before or after the query execution, you should wrap the invocation of the named
+      # query in another method.
+      #
+      # @param [Symbol] name the name of the method that will be defined
+      # @param [Proc] body a lambda that wraps an ActiveRecord query
+      def self.readyset_query(name, body)
+        unless body.respond_to?(:call)
+          raise ArgumentError, 'The query body needs to be callable.'
+        end
+
+        if dangerous_class_method?(name)
+          raise ArgumentError, "You tried to define a ReadySet query named \"#{name}\" " \
+            "on the model \"#{self.name}\", but Active Record already defined " \
+            'a class method with the same name.'
+        end
+
+        if method_defined_within?(name, ActiveRecord::Relation)
+          raise ArgumentError, "You tried to define a ReadySet query named \"#{name}\" " \
+            "on the model \"#{self.name}\", but ActiveRecord::Relation already defined " \
+            'an instance method with the same name.'
+        end
+
+        singleton_class.define_method(name) do |*args|
+          Readyset.route { body.call(*args) }
+        end
+      end
+    end
+  end
+end

--- a/lib/readyset/railtie.rb
+++ b/lib/readyset/railtie.rb
@@ -10,6 +10,7 @@ module Readyset
 
     initializer 'readyset.active_record' do |app|
       ActiveSupport.on_load(:active_record) do
+        ActiveRecord::Base.prepend(Readyset::ModelExtension)
         ActiveRecord::Relation.prepend(Readyset::RelationExtension)
       end
     end

--- a/spec/model_extension_spec.rb
+++ b/spec/model_extension_spec.rb
@@ -1,0 +1,60 @@
+# spec/model_extension_spec.rb
+
+RSpec.describe Readyset::ModelExtension do
+  describe '.readyset_query' do
+    subject { Cat.readyset_query(name, body) }
+
+    context 'when the body is not callable' do
+      let(:body) { 'I am not callable' }
+      let(:name) { :find_by_name_cached }
+
+      it 'raises an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when the query's name would overwrite a predefined class method" do
+      let(:body) { ->(name) { Cat.where(name: name) } }
+      let(:name) { :all }
+
+      it 'raises an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when the query's name would overwrite a predefined ActiveRecord::Relation method" do
+      let(:body) { ->(name) { Cat.where(name: name) } }
+      let(:name) { :load }
+
+      it 'raises an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when the body is callable and the name is valid' do
+      let(:name) { :find_by_name_cached }
+      let(:body) { ->(name) { Cat.where(name: name) } }
+
+      before do
+        # Add a few records to the database that is acting as our fake ReadySet instance
+        Readyset.route(prevent_writes: false) do
+          Cat.create!(name: 'whiskers')
+          Cat.create!(name: 'fluffy')
+          Cat.create!(name: 'tails')
+        end
+
+        subject
+      end
+
+      it "defines a method on the model's class" do
+        expect(Cat).to respond_to(name)
+      end
+
+      it 'defines a method that returns query results from ReadySet' do
+        results = Cat.find_by_name_cached('whiskers')
+        expect(results.size).to eq(1)
+        expect(results.first.name).to eq('whiskers')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds an extension to `ActiveRecord::Base` that defines a `readyset_query` class method. This class method provides an easy interface for users to define named queries within the context of their models such that the queries will be routed to ReadySet.

NOTE: This PR is stacked on top of #47 and should only be merged after that PR is merged

Closes #3 