### PR TITLE
readyset: Fix create/drop cache methods

### DIFF
--- a/lib/readyset.rb
+++ b/lib/readyset.rb
@@ -36,49 +36,30 @@ module Readyset
   end
 
   # Creates a new cache on ReadySet using the given ReadySet query ID or SQL query.
-  # @param id [String] the ReadySet query ID of the query from which a cache should be created.
-  # @param sql [String] the SQL string from which a cache should be created.
+  # @param id_or_sql [String] the query ID or SQL string from which a cache should be created.
   # @param name [String] the name for the cache being created.
   # @param always [Boolean] whether the cache should always be used;
   # queries to these caches will never fall back to the database if this is true.
   # @return [void]
-  # @raise [ArgumentError] raised if exactly one of the `id` or `sql` arguments was not provided.
-  def self.create_cache!(id: nil, sql: nil, name: nil, always: false)
-    if (sql.nil? && id.nil?) || (!sql.nil? && !id.nil?)
-      raise ArgumentError, 'Exactly one of the `id` and `sql` parameters must be provided'
-    end
-
-    suffix = sql ? '%s' : '?'
-    from = (id || sql)
-
+  def self.create_cache!(id_or_sql, name: nil, always: false)
     if always && name
-      raw_query('CREATE CACHE ALWAYS ? FROM ' + suffix, name, from)
+      raw_query('CREATE CACHE ALWAYS %s FROM %s', name, id_or_sql)
     elsif always
-      raw_query('CREATE CACHE ALWAYS FROM ' + suffix, from)
+      raw_query('CREATE CACHE ALWAYS FROM %s', id_or_sql)
     elsif name
-      raw_query('CREATE CACHE ? FROM ' + suffix, name, from)
+      raw_query('CREATE CACHE %s FROM %s', name, id_or_sql)
     else
-      raw_query('CREATE CACHE FROM ' + suffix, from)
+      raw_query('CREATE CACHE FROM %s', id_or_sql)
     end
 
     nil
   end
 
-  # Drops an existing cache on ReadySet using the given SQL query or ReadySet query ID.
-  # @param name_or_id [String] the name or ReadySet query ID of the cache that should be dropped.
-  # @param sql [String] a SQL string for a query whose associated cache should be dropped.
+  # Drops an existing cache on ReadySet.
+  # @param query_identifier [String] the name of the cache that should be dropped
   # @return [void]
-  # @raise [ArgumentError] if exactly one of the `name_or_id` or `sql` arguments was not provided.
-  def self.drop_cache!(name_or_id: nil, sql: nil)
-    if (sql.nil? && name_or_id.nil?) || (!sql.nil? && !name_or_id.nil?)
-      raise ArgumentError, 'Exactly one of the `name_or_id` and `sql` parameters must be provided'
-    end
-
-    if sql
-      raw_query('DROP CACHE %s', sql)
-    else
-      raw_query('DROP CACHE ?', name_or_id)
-    end
+  def self.drop_cache!(query_identifier)
+    raw_query('DROP CACHE %s', query_identifier)
 
     nil
   end

--- a/spec/ready_set_spec.rb
+++ b/spec/ready_set_spec.rb
@@ -20,70 +20,45 @@ RSpec.describe Readyset do
   describe '.create_cache!' do
     let(:query) { build(:proxied_query) }
 
-    context 'when given neither a SQL string nor an ID' do
-      subject { Readyset.create_cache! }
+    subject { Readyset.create_cache!(query.id) }
 
-      it 'raises an ArgumentError' do
-        expect { subject }.to raise_error(ArgumentError)
-      end
-    end
-
-    context 'when given both a SQL string and an ID' do
-      subject { Readyset.create_cache!(sql: query.text, id: query.id) }
-
-      it 'raises an ArgumentError' do
-        expect { subject }.to raise_error(ArgumentError)
-      end
-    end
-
-    context 'when given a SQL string but not an ID' do
-      subject { Readyset.create_cache!(sql: query.text) }
-
-      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE FROM %s' do
-        let(:args) { [query.text] }
-      end
-    end
-
-    context 'when given an ID but not a SQL string' do
-      subject { Readyset.create_cache!(id: query.id) }
-
-      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE FROM ?' do
-        let(:args) { [query.id] }
-      end
+    it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE FROM %s' do
+      let(:args) { [query.id] }
     end
 
     context 'when only the "always" parameter is passed' do
-      subject { Readyset.create_cache!(id: query.id, always: true) }
+      subject { Readyset.create_cache!(query.id, always: true) }
 
-      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE ALWAYS FROM ?' do
+      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE ALWAYS FROM %s' do
         let(:args) { [query.id] }
       end
     end
 
     context 'when only the "name" parameter is passed' do
-      subject { Readyset.create_cache!(id: query.id, name: name) }
+      subject { Readyset.create_cache!(query.id, name: name) }
 
       let(:name) { 'test cache' }
 
-      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE ? FROM ?' do
+      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE %s FROM %s' do
         let(:args) { [name, query.id] }
       end
     end
 
     context 'when both the "always" and "name" parameters are passed' do
-      subject { Readyset.create_cache!(id: query.id, always: true, name: name) }
+      subject { Readyset.create_cache!(query.id, always: true, name: name) }
 
       let(:name) { 'test cache' }
 
-      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE ALWAYS ? FROM ?' do
+      it_behaves_like 'a wrapper around a ReadySet SQL extension',
+          'CREATE CACHE ALWAYS %s FROM %s' do
         let(:args) { [name, query.id] }
       end
     end
 
     context 'when neither the "always" nor the "name" parameters are passed' do
-      subject { Readyset.create_cache!(id: query.id) }
+      subject { Readyset.create_cache!(query.id) }
 
-      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE FROM ?' do
+      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE FROM %s' do
         let(:args) { [query.id] }
       end
     end
@@ -92,36 +67,10 @@ RSpec.describe Readyset do
   describe '.drop_cache!' do
     let(:query) { build(:proxied_query) }
 
-    context 'when given neither a SQL string nor an ID' do
-      subject { Readyset.drop_cache! }
+    subject { Readyset.drop_cache!(query.id) }
 
-      it 'raises an ArgumentError' do
-        expect { subject }.to raise_error(ArgumentError)
-      end
-    end
-
-    context 'when given both a SQL string and an ID' do
-      subject { Readyset.drop_cache!(sql: query.text, name_or_id: query.id) }
-
-      it 'raises an ArgumentError' do
-        expect { subject }.to raise_error(ArgumentError)
-      end
-    end
-
-    context 'when given a SQL string but not an ID' do
-      subject { Readyset.drop_cache!(sql: query.text) }
-
-      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'DROP CACHE %s' do
-        let(:args) { [query.text] }
-      end
-    end
-
-    context 'when given an ID but not a SQL string' do
-      subject { Readyset.drop_cache!(name_or_id: query.id) }
-
-      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'DROP CACHE ?' do
-        let(:args) { [query.id] }
-      end
+    it_behaves_like 'a wrapper around a ReadySet SQL extension', 'DROP CACHE %s' do
+      let(:args) { [query.id] }
     end
   end
 


### PR DESCRIPTION
`Readyset.create_cache!` and `Readyset.drop_cache!` each quoted the query ID/name before sending the query to ReadySet. This was incorrect: ReadySet query IDs/names are not string literals but rather identifiers. This commit fixes the issue by creating the `CREATE CACHE` and `DROP CACHE` query strings using unquoted query IDs/names.