### PR TITLE
readyset: Fix quoting in create/drop cache methods

### DIFF
--- a/spec/ready_set_spec.rb
+++ b/spec/ready_set_spec.rb
@@ -18,60 +18,62 @@ RSpec.describe Readyset do
   end
 
   describe '.create_cache!' do
-    let(:query) { build(:proxied_query) }
+    context 'when given neither a SQL string nor an ID' do
+      subject { Readyset.create_cache! }
 
-    subject { Readyset.create_cache!(query.id) }
+      it 'raises an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
 
-    it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE FROM %s' do
-      let(:args) { [query.id] }
+    context 'when given both a SQL string and an ID' do
+      subject { Readyset.create_cache!(sql: 'SELECT * FROM t WHERE x = 1', id: 'fake_query_id') }
+
+      it 'raises an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when given a SQL string but not an ID' do
+      subject { Readyset.create_cache!(sql: 'SELECT * FROM t WHERE x = 1') }
+
+      it_behaves_like 'a wrapper around a ReadySet SQL extension',
+        'CREATE CACHE FROM SELECT * FROM t WHERE x = 1'
+    end
+
+    context 'when given an ID but not a SQL string' do
+      subject { Readyset.create_cache!(id: 'fake_query_id') }
+
+      it_behaves_like 'a wrapper around a ReadySet SQL extension',
+        'CREATE CACHE FROM "fake_query_id"'
     end
 
     context 'when only the "always" parameter is passed' do
-      subject { Readyset.create_cache!(query.id, always: true) }
+      subject { Readyset.create_cache!(id: 'fake_query_id', always: true) }
 
-      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE ALWAYS FROM %s' do
-        let(:args) { [query.id] }
-      end
+      it_behaves_like 'a wrapper around a ReadySet SQL extension',
+        'CREATE CACHE ALWAYS FROM "fake_query_id"'
     end
 
     context 'when only the "name" parameter is passed' do
-      subject { Readyset.create_cache!(query.id, name: name) }
+      subject { Readyset.create_cache!(id: 'fake_query_id', name: 'test_cache') }
 
-      let(:name) { 'test cache' }
-
-      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE %s FROM %s' do
-        let(:args) { [name, query.id] }
-      end
+      it_behaves_like 'a wrapper around a ReadySet SQL extension',
+        'CREATE CACHE "test_cache" FROM "fake_query_id"'
     end
 
     context 'when both the "always" and "name" parameters are passed' do
-      subject { Readyset.create_cache!(query.id, always: true, name: name) }
-
-      let(:name) { 'test cache' }
+      subject { Readyset.create_cache!(id: 'fake_query_id', always: true, name: 'test_cache') }
 
       it_behaves_like 'a wrapper around a ReadySet SQL extension',
-          'CREATE CACHE ALWAYS %s FROM %s' do
-        let(:args) { [name, query.id] }
-      end
-    end
-
-    context 'when neither the "always" nor the "name" parameters are passed' do
-      subject { Readyset.create_cache!(query.id) }
-
-      it_behaves_like 'a wrapper around a ReadySet SQL extension', 'CREATE CACHE FROM %s' do
-        let(:args) { [query.id] }
-      end
+        'CREATE CACHE ALWAYS "test_cache" FROM "fake_query_id"'
     end
   end
 
   describe '.drop_cache!' do
-    let(:query) { build(:proxied_query) }
+    subject { Readyset.drop_cache!('query_name') }
 
-    subject { Readyset.drop_cache!(query.id) }
-
-    it_behaves_like 'a wrapper around a ReadySet SQL extension', 'DROP CACHE %s' do
-      let(:args) { [query.id] }
-    end
+    it_behaves_like 'a wrapper around a ReadySet SQL extension', 'DROP CACHE "query_name"'
   end
 
   describe '.raw_query' do


### PR DESCRIPTION
This commit fixes the identifier quoting in our Readyset.create_cache! and Readyset.drop_cache! methods. Specifically, the query name passed to `DROP CACHE` should always be quoted (since it's an identifier) and if we are passing an ID to `CREATE CACHE`, we need to quote that as well. The main idea here is that whenever we pass the a query ID or query name to `CREATE CACHE` or `DROP CACHE`, it needs to be quoted, and whenever we pass a query string to `CREATE CACHE` it should not be quoted.

This PR includes a revert of #64 and some additional logic to properly handle the quoting.

Fixes #63