### PR TITLE
specs: Run tests against live instances

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   rspec:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -22,5 +21,9 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
+
+    - name: Start Docker images
+      run: docker-compose -f docker-compose.yml up -d
+
     - name: Run tests
       run: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,3 @@
 .rspec_status
 Gemfile.lock
 spec/internal/tmp/
-spec/internal/config/storage.yml
-spec/internal/db/*.sqlite
-spec/internal/db/*.sqlite-shm
-spec/internal/db/*.sqlite-wal

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,1 @@
---format documentation
---color
 --require rails_helper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  readyset:
+    image: public.ecr.aws/readyset/readyset:latest-stable
+    platform: linux/amd64
+    ports:
+      # The ReadySet Adapter listen port, i.e. what your application / SQL shell connects to
+      - "5433:5433"
+      # ReadySet Prometheus metrics available at http://localhost:6034/metrics
+      # e.g. curl -X GET http://localhost:6034/metrics
+      - "6034:6034"
+    environment:
+      DEPLOYMENT_ENV: readyset_rails_test
+      DB_DIR: /state
+      QUERY_CACHING: explicit
+      STANDALONE: 'true'
+      DEPLOYMENT: docker_compose_deployment
+      LISTEN_ADDRESS: 0.0.0.0:5433
+      UPSTREAM_DB_URL: postgresql://postgres:readyset@postgres/testdb
+      CONTROLLER_ADDRESS: 0.0.0.0
+    volumes:
+      - "readyset:/state"
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "127.0.0.1:6034/health" ]
+      interval: 2s
+      timeout: 1s
+      retries: 5
+      start_period: 5s
+    depends_on:
+      postgres:
+        condition: service_healthy
+  postgres:
+    image: postgres:14
+    environment:
+      - POSTGRES_PASSWORD=readyset
+      - POSTGRES_DB=testdb
+    ports:
+      # The ReadySet Adapter listen port, i.e. what your application / SQL shell connects to
+      - "5432:5432"
+    expose:
+      - 5432
+    command:
+      - "postgres"
+      - "-c"
+      - "wal_level=logical"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    volumes:
+      - postgres:/var/lib/postgresql/data
+volumes:
+  postgres: ~
+  readyset: ~

--- a/lib/readyset.rb
+++ b/lib/readyset.rb
@@ -100,9 +100,13 @@ module Readyset
   # @note This method is not part of the public API.
   # @param sql_array [Array<Object>] the SQL array to be executed against ReadySet.
   # @return [PG::Result] the result of executing the SQL query.
-  def self.raw_query(*sql_array) # :nodoc:
+  def self.raw_query_sanitize(*sql_array) # :nodoc:
+    raw_query(ActiveRecord::Base.sanitize_sql_array(sql_array))
+  end
+
+  def self.raw_query(query) # :nodoc:
     ActiveRecord::Base.connected_to(role: writing_role, shard: shard, prevent_writes: false) do
-      ActiveRecord::Base.connection.execute(ActiveRecord::Base.sanitize_sql_array(sql_array))
+      ActiveRecord::Base.connection.execute(query)
     end
   end
 

--- a/lib/readyset/explain.rb
+++ b/lib/readyset/explain.rb
@@ -12,7 +12,7 @@ module Readyset
     # @param [String] a query about which information should be retrieved
     # @return [Explain]
     def self.call(query)
-      raw_results = Readyset.raw_query('EXPLAIN CREATE CACHE FROM %s', query)
+      raw_results = Readyset.raw_query("EXPLAIN CREATE CACHE FROM #{query}")
       from_readyset_results(**raw_results.first.to_h.symbolize_keys)
     end
 

--- a/lib/readyset/query/cached_query.rb
+++ b/lib/readyset/query/cached_query.rb
@@ -61,8 +61,7 @@ module Readyset
         id == other.id &&
           text == other.text &&
           name == other.name &&
-          always == other.always &&
-          count == other.count
+          always == other.always
       end
 
       # Returns false if the cached query supports falling back to the upstream database and true
@@ -77,8 +76,8 @@ module Readyset
       #
       # @return [void]
       def drop!
-        Readyset.drop_cache!(name_or_id: id)
-        ProxiedQuery.find(id: id)
+        Readyset.drop_cache!(name)
+        ProxiedQuery.find(id)
       end
 
       private

--- a/lib/readyset/query/proxied_query.rb
+++ b/lib/readyset/query/proxied_query.rb
@@ -38,6 +38,11 @@ module Readyset
           map { |query| query.cache!(always: always) }
       end
 
+      # Clears the list of proxied queries on ReadySet.
+      def self.drop_all!
+        Readyset.raw_query('DROP ALL PROXIED QUERIES')
+      end
+
       # Returns the proxied query with the given query ID. The query is searched for by directly
       # querying ReadySet. If a proxied query with the given ID doesn't exist, this method raises a
       # `Readyset::Query::NotFoundError`.
@@ -69,8 +74,7 @@ module Readyset
       def ==(other)
         id == other.id &&
           text == other.text &&
-          supported == other.supported &&
-          count == other.count
+          supported == other.supported
       end
 
       # Creates a cache on ReadySet for this query.

--- a/lib/readyset/query/queryable.rb
+++ b/lib/readyset/query/queryable.rb
@@ -10,7 +10,7 @@ module Readyset
       end
 
       def find(query, id) # :nodoc:
-        result = Readyset.raw_query(query, id).first
+        result = Readyset.raw_query_sanitize(query, id).first
 
         if result.nil?
           raise NotFoundError, id

--- a/lib/readyset/relation_extension.rb
+++ b/lib/readyset/relation_extension.rb
@@ -10,21 +10,11 @@ module Readyset
       # the queries issued to do the eager loading will not have caches created. Those queries must
       # have their caches created separately.
       #
+      # @param always [Boolean] whether the queries to this cache should always be served by
+      #                         ReadySet, preventing fallback to the uptream database
       # @return [void]
-      def create_readyset_cache!
-        Readyset.create_cache!(sql: to_sql)
-      end
-
-      # Drops the cache on ReadySet associated with this query. This method is a no-op if a cache
-      # for the query already doesn't exist.
-      #
-      # NOTE: If the ActiveRecord query eager loads associations (e.g. via `#includes`), the
-      # the queries issued to do the eager loading will not have caches dropped. Those queries must
-      # have their caches dropped separately.
-      #
-      # @return [void]
-      def drop_readyset_cache!
-        Readyset.drop_cache!(sql: to_sql)
+      def create_readyset_cache!(always: false)
+        Readyset.create_cache!(to_sql, always: always)
       end
 
       # Gets information about this query from ReadySet, including the query's ID, the normalized

--- a/readyset.gemspec
+++ b/readyset.gemspec
@@ -40,9 +40,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'combustion', '~> 1.3'
   spec.add_development_dependency 'factory_bot', '~> 6.4'
+  spec.add_development_dependency 'pg', '~> 1.5'
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'rspec-rails', '~> 6.0'
   spec.add_development_dependency 'rubocop-airbnb'
-  spec.add_development_dependency 'sqlite3', '~> 1.6'
-  spec.add_development_dependency 'pry'
 end

--- a/spec/explain_spec.rb
+++ b/spec/explain_spec.rb
@@ -6,13 +6,6 @@ RSpec.describe Readyset::Explain do
   describe '.call' do
     it 'retrieves the explain information from ReadySet' do
       explain = build(:explain)
-      raw_result = {
-        :'query id' => explain.id,
-        :'readyset supported' => explain.supported,
-        query: explain.text,
-      }
-      allow(Readyset).to receive(:raw_query).with('EXPLAIN CREATE CACHE FROM %s', explain.text).
-        and_return([raw_result])
 
       result = Readyset::Explain.call(explain.text)
 

--- a/spec/factories/cached_query.rb
+++ b/spec/factories/cached_query.rb
@@ -1,20 +1,50 @@
 FactoryBot.define do
   factory :cached_query, class: 'Readyset::Query::CachedQuery' do
-    id { 'q_eafb620c78f5b9ac' }
-    count { 5 }
-    text { 'SELECT * FROM "t" WHERE ("x" = $1)' }
-    name { 'q_eafb620c78f5b9ac' }
+    id { 'q_4f3fb9ad8f73bc0c' }
     always { false }
+    count { 0 }
+    text do
+      <<~SQL.chomp
+        SELECT
+          "public"."cats"."breed"
+        FROM
+          "public"."cats"
+        WHERE
+          ("public"."cats"."name" = $1)
+      SQL
+    end
+    name { 'q_4f3fb9ad8f73bc0c' }
 
-    initialize_with { new(**attributes) }
-  end
+    factory :cached_query_2 do
+      id { 'q_803a0358269d346d' }
+      name { 'q_803a0358269d346d' }
+      text do
+        <<~SQL.chomp
+          SELECT
+            "public"."cats"."name"
+          FROM
+            "public"."cats"
+          WHERE
+            ("public"."cats"."breed" = $1)
+        SQL
+      end
+      always { true }
+    end
 
-  factory :cached_query_2, class: 'Readyset::Query::CachedQuery' do
-    id { 'q_8892818e62c34ecd' }
-    count { 5 }
-    text { 'SELECT * FROM "t" WHERE ("y" = $1)' }
-    name { 'q_8892818e62c34ecd' }
-    always { true }
+    factory :cached_query_3 do
+      id { 'q_699461ae91ebc79b' }
+      name { 'q_699461ae91ebc79b' }
+      text do
+        <<~SQL.chomp
+          SELECT
+            COUNT(*)
+          FROM
+            "cats"
+          WHERE
+            ("cats"."breed" = $1)
+        SQL
+      end
+    end
 
     initialize_with { new(**attributes) }
   end

--- a/spec/factories/cat.rb
+++ b/spec/factories/cat.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :cat, class: 'Cat' do
+    name { 'Whiskers' }
+  end
+end

--- a/spec/factories/explain.rb
+++ b/spec/factories/explain.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :explain, class: 'Readyset::Explain' do
-    id { 'q_eafb620c78f5b9ac' }
-    text { 'SELECT * FROM "t" WHERE ("x" = $1)' }
+    id { 'q_4f3fb9ad8f73bc0c' }
+    text { 'SELECT "cats"."breed" FROM "cats" WHERE ("cats"."name" = $1)' }
     supported { :yes }
 
     initialize_with { new(**attributes) }

--- a/spec/factories/proxied_query.rb
+++ b/spec/factories/proxied_query.rb
@@ -1,13 +1,45 @@
 FactoryBot.define do
   factory :proxied_query, class: 'Readyset::Query::ProxiedQuery' do
-    id { 'q_eafb620c78f5b9ac' }
-    count { 5 }
-
-    text { 'SELECT * FROM "t" WHERE ("x" = $1)' }
+    id { 'q_4f3fb9ad8f73bc0c' }
+    count { 0 }
+    text do
+      <<~SQL.chomp
+        SELECT
+          "cats"."breed"
+        FROM
+          "cats"
+        WHERE
+          ("cats"."name" = $1)
+      SQL
+    end
     supported { :yes }
 
-    factory :pending_proxied_query do
-      supported { :pending }
+    factory :proxied_query_2 do
+      id { 'q_803a0358269d346d' }
+      text do
+        <<~SQL.chomp
+          SELECT
+            "cats"."name"
+          FROM
+            "cats"
+          WHERE
+            ("cats"."breed" = $1)
+        SQL
+      end
+    end
+
+    factory :proxied_query_3 do
+      id { 'q_803a0358269d346d' }
+      text do
+        <<~SQL.chomp
+          SELECT
+            COUNT(*)
+          FROM
+            "cats"
+          WHERE
+            ("cats"."breed" = $1)
+        SQL
+      end
     end
 
     factory :unsupported_proxied_query do

--- a/spec/internal/config/database.yml
+++ b/spec/internal/config/database.yml
@@ -1,8 +1,15 @@
+default: &default
+  database: testdb
+  username: postgres
+  password: readyset
+  adapter: postgresql
+  host: "127.0.0.1"
+
 test:
   primary:
-    adapter:  sqlite3
-    database: db/combustion_test.sqlite
+    <<: *default
+    port: 5432
   readyset:
-    adapter:  sqlite3
-    database: db/combustion_test_readyset.sqlite
+    <<: *default
+    port: 5433
 

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -3,6 +3,7 @@
 ActiveRecord::Schema.define do
   create_table(:cats, :force => true) do |t|
     t.string :name
+    t.string :breed
     t.timestamps
   end
 end

--- a/spec/model_extension_spec.rb
+++ b/spec/model_extension_spec.rb
@@ -36,12 +36,9 @@ RSpec.describe Readyset::ModelExtension do
       let(:body) { ->(name) { Cat.where(name: name) } }
 
       before do
-        # Add a few records to the database that is acting as our fake ReadySet instance
-        Readyset.route(prevent_writes: false) do
-          Cat.create!(name: 'whiskers')
-          Cat.create!(name: 'fluffy')
-          Cat.create!(name: 'tails')
-        end
+        Cat.create(name: 'whiskers')
+        Cat.create(name: 'fluffy')
+        Cat.create(name: 'tails')
 
         subject
       end
@@ -51,7 +48,10 @@ RSpec.describe Readyset::ModelExtension do
       end
 
       it 'defines a method that returns query results from ReadySet' do
+        expect(Readyset).to receive(:route).and_call_original
+
         results = Cat.find_by_name_cached('whiskers')
+
         expect(results.size).to eq(1)
         expect(results.first.name).to eq('whiskers')
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,7 +42,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false

--- a/spec/relation_extension_spec.rb
+++ b/spec/relation_extension_spec.rb
@@ -2,60 +2,21 @@
 
 RSpec.describe Readyset::RelationExtension do
   describe '#create_readyset_cache!' do
-    subject { query.create_readyset_cache! }
+    it 'creates a cache on ReadySet with the given "always" parameter' do
+      cache = build_and_create_cache(:cached_query)
 
-    let(:query_string) { query.to_sql }
-    let(:query) { Cat.where(id: 1) }
+      caches = Readyset::Query::CachedQuery.all
 
-    before do
-      allow(Readyset).to receive(:create_cache!).with(sql: query_string)
-      subject
-    end
-
-    it "invokes `Readyset.create_cache!` with the relation's query string" do
-      expect(Readyset).to have_received(:create_cache!).with(sql: query_string)
-    end
-  end
-
-  describe '#drop_readyset_cache!' do
-    subject { query.drop_readyset_cache! }
-
-    let(:query_string) { query.to_sql }
-    let(:query) { Cat.where(id: 1) }
-
-    before do
-      allow(Readyset).to receive(:drop_cache!).with(sql: query_string)
-      subject
-    end
-
-    it "invokes `Readyset.drop_cache!` with the relation's query string" do
-      expect(Readyset).to have_received(:drop_cache!).with(sql: query_string)
+      expect(caches).to eq([cache])
     end
   end
 
   describe '#readyset_explain' do
-    it "invokes `Readyset.readyset_explain` with the relation's query string" do
-      query = Cat.where(id: 1)
-      query_string = query.to_sql
-      allow(Readyset).to receive(:explain).with(query_string).
-        and_return(instance_double(Readyset::Explain))
-
-      query.readyset_explain
-
-      expect(Readyset).to have_received(:explain).with(query_string)
-    end
-
     it 'returns the expected explain information' do
-      query = Cat.where(id: 1)
-      query_string = query.to_sql
-      explain = Readyset::Explain.new(id: 'q_0000000000000000',
-                                      text: 'SELECT * FROM "cats" WHERE ("id" = $1)',
-                                      supported: :yes)
-      allow(Readyset).to receive(:explain).with(query_string).and_return(explain)
+      output = Cat.select('breed').where(name: 'Whiskers').readyset_explain
 
-      output = query.readyset_explain
-
-      expect(output).to eq(explain)
+      expected_explain = build(:explain)
+      expect(output).to eq(expected_explain)
     end
   end
 end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -3,17 +3,6 @@ RSpec.shared_examples 'a wrapper around a ReadySet SQL extension' do |sql_comman
   let(:expected_output) { nil }
   let(:raw_query_result) { [] }
 
-  before do
-    allow(Readyset).to receive(:raw_query).with(sql_command, *args).
-      and_return(raw_query_result)
-
-    subject
-  end
-
-  it "invokes \"#{sql_command}\" on ReadySet" do
-    expect(Readyset).to have_received(:raw_query).with(sql_command, *args)
-  end
-
   it 'returns the expected result' do
     expect(subject).to eq(expected_output)
   end


### PR DESCRIPTION
**Note: This PR is stacked on top of #66 and should not be merged until that is merged**

This commit:
1. Adds code to run Postgres and ReadySet instances in CI
2. Updates the tests to run against live Postgres and ReadySet instances
   instead of relying upon stubbing