### PR TITLE
treewide: Remove Ruby 2.7 support

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from:
   - .rubocop_airbnb.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.2
   NewCops: disable
 
 Style/StringLiterals:

--- a/readyset.gemspec
+++ b/readyset.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
                  'SQL cache.'
   spec.description = 'This gem provides a Rails adapter to the ReadySet SQL cache.'
   spec.homepage = 'https://readyset.io'
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.metadata['allowed_push_host'] = "TODO: Set to your gem server 'https://example.com'"
 


### PR DESCRIPTION
This commit removes support for Ruby 2.7 given that its EOL was reached on 2023-03-31.