### PR TITLE
status: Add `Status` and `Table` classes

### DIFF
--- a/lib/readyset.rb
+++ b/lib/readyset.rb
@@ -10,6 +10,8 @@ require 'readyset/query/cached_query'
 require 'readyset/query/proxied_query'
 require 'readyset/railtie' if defined?(Rails::Railtie)
 require 'readyset/relation_extension'
+require 'readyset/status'
+require 'readyset/table'
 
 # The Readyset module provides functionality to integrate ReadySet caching
 # with Ruby on Rails applications.

--- a/lib/readyset/status.rb
+++ b/lib/readyset/status.rb
@@ -19,9 +19,9 @@ module Readyset
     end
 
     def initialize(connection_count:, controller_status:, database_connection_status:,
-        last_completed_snapshot:, last_replicator_error:, last_started_controller:,
-        last_started_replication:, minimum_replication_offset:, maximum_replication_offset:,
-        snapshot_status:) # :nodoc:
+                   last_completed_snapshot:, last_replicator_error:, last_started_controller:,
+                   last_started_replication:, minimum_replication_offset:,
+                   maximum_replication_offset:, snapshot_status:) # :nodoc:
       @connection_count = connection_count
       @database_connection_status = database_connection_status
       @last_completed_snapshot = last_completed_snapshot
@@ -41,11 +41,13 @@ module Readyset
 
       new(
         connection_count: attributes['Connection Count'].to_i,
-        database_connection_status: attributes['Database Connection'].downcase.gsub(' ', '_').to_sym,
+        database_connection_status:
+          attributes['Database Connection'].downcase.gsub(' ', '_').to_sym,
         last_completed_snapshot: parse_timestamp_if_not_nil(attributes['Last completed snapshot']),
         last_replicator_error: attributes['Last replicator error'],
         last_started_controller: parse_timestamp_if_not_nil(attributes['Last started Controller']),
-        last_started_replication: parse_timestamp_if_not_nil(attributes['Last started replication']),
+        last_started_replication:
+          parse_timestamp_if_not_nil(attributes['Last started replication']),
         minimum_replication_offset: attributes['Minimum Replication Offset'],
         maximum_replication_offset: attributes['Maximum Replication Offset'],
         controller_status: attributes['ReadySet Controller Status'],

--- a/lib/readyset/status.rb
+++ b/lib/readyset/status.rb
@@ -1,0 +1,64 @@
+require 'active_model'
+
+module Readyset
+  # Represents ReadySet's current status.
+  class Status
+    include ActiveModel::AttributeMethods
+
+    attr_reader :connection_count, :controller_status, :database_connection_status,
+      :last_completed_snapshot, :last_replicator_error, :last_started_controller,
+      :last_started_replication, :minimum_replication_offset, :maximum_replication_offset,
+      :snapshot_status
+
+    # Returns a list of all the tables known by ReadySet along with their statuses. This
+    # information is retrieved by invoking `SHOW READYSET STATUS` on ReadySet.
+    #
+    # @return [Array<ReadySet::Table>]
+    def self.call
+      from_readyset_result(Readyset.raw_query('SHOW READYSET STATUS'))
+    end
+
+    def initialize(connection_count:, controller_status:, database_connection_status:,
+        last_completed_snapshot:, last_replicator_error:, last_started_controller:,
+        last_started_replication:, minimum_replication_offset:, maximum_replication_offset:,
+        snapshot_status:) # :nodoc:
+      @connection_count = connection_count
+      @database_connection_status = database_connection_status
+      @last_completed_snapshot = last_completed_snapshot
+      @last_replicator_error = last_replicator_error
+      @last_started_controller = last_started_controller
+      @last_started_replication = last_started_replication
+      @minimum_replication_offset = minimum_replication_offset
+      @maximum_replication_offset = maximum_replication_offset
+      @controller_status = controller_status
+      @snapshot_status = snapshot_status
+    end
+
+    private
+
+    def self.from_readyset_result(rows)
+      attributes = rows.each_with_object({}) { |row, acc| acc[row['name']] = row['value'] }
+
+      new(
+        connection_count: attributes['Connection Count'].to_i,
+        database_connection_status: attributes['Database Connection'].downcase.gsub(' ', '_').to_sym,
+        last_completed_snapshot: parse_timestamp_if_not_nil(attributes['Last completed snapshot']),
+        last_replicator_error: attributes['Last replicator error'],
+        last_started_controller: parse_timestamp_if_not_nil(attributes['Last started Controller']),
+        last_started_replication: parse_timestamp_if_not_nil(attributes['Last started replication']),
+        minimum_replication_offset: attributes['Minimum Replication Offset'],
+        maximum_replication_offset: attributes['Maximum Replication Offset'],
+        controller_status: attributes['ReadySet Controller Status'],
+        snapshot_status: attributes['Snapshot Status'].downcase.gsub(' ', '_').to_sym,
+      )
+    end
+    private_class_method :from_readyset_result
+
+    def self.parse_timestamp_if_not_nil(timestamp)
+      unless timestamp.nil?
+        Time.parse(timestamp)
+      end
+    end
+    private_class_method :parse_timestamp_if_not_nil
+  end
+end

--- a/lib/readyset/table.rb
+++ b/lib/readyset/table.rb
@@ -1,0 +1,62 @@
+require 'active_model'
+
+module Readyset
+  # Represents a table from the database as it is known by ReadySet.
+  class Table
+    include ActiveModel::AttributeMethods
+
+    # An error raised when a table is expected to be replicated but isn't.
+    class NotReplicatedError < StandardError
+      attr_reader :description, :name
+
+      def initialize(name, description)
+        @name = name
+        @description = description
+      end
+
+      def to_s
+        "Table #{name} is not replicated: #{description}"
+      end
+    end
+
+    attr_reader :description, :name, :status
+
+    # Returns a list of all the tables known by ReadySet along with their statuses. This
+    # information is retrieved by invoking `SHOW READYSET TABLES` on ReadySet.
+    #
+    # @return [Array<ReadySet::Table>]
+    def self.all
+      Readyset.raw_query('SHOW READYSET TABLES').map do |result|
+        from_readyset_result(**result.to_h.symbolize_keys)
+      end
+    end
+
+    def initialize(name:, status:, description:) # :nodoc:
+      @name = name
+      @status = status
+      @description = description
+    end
+
+    # Compares two Readyset::Tables attribute-wise, returning true only if all the attributes
+    # match across `self` and `other`.
+    #
+    # @param other [Readyset::Table] the table to which `self` should be compared
+    # @return [Boolean]
+    def ==(other) # :nodoc:
+      self.name == other.name &&
+        self.description == other.description &&
+        self.status == other.status
+    end
+
+    private
+
+    def self.from_readyset_result(**attributes)
+      new(
+        name: attributes[:table],
+        status: attributes[:status].downcase.gsub(' ', '_').to_sym,
+        description: attributes[:description]
+      )
+    end
+    private_class_method :from_readyset_result
+  end
+end

--- a/lib/readyset/table.rb
+++ b/lib/readyset/table.rb
@@ -43,9 +43,9 @@ module Readyset
     # @param other [Readyset::Table] the table to which `self` should be compared
     # @return [Boolean]
     def ==(other) # :nodoc:
-      self.name == other.name &&
-        self.description == other.description &&
-        self.status == other.status
+      name == other.name &&
+        description == other.description &&
+        status == other.status
     end
 
     private

--- a/spec/factories/status.rb
+++ b/spec/factories/status.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :status, class: 'Readyset::Status' do
+    connection_count { 5 }
+    database_connection_status { :connected }
+    last_completed_snapshot { Time.parse('2023-11-22 16:40:34') }
+    last_replicator_error { 'test error' }
+    last_started_controller { Time.parse('2023-11-22 16:40:34') }
+    last_started_replication { Time.parse('2023-11-22 16:40:34') }
+    maximum_replication_offset { '(0/33ED51B8, 0/33ED51E8)' }
+    minimum_replication_offset { '(0/33ED51B8, 0/33ED51E8)' }
+    controller_status { 'test status' }
+    snapshot_status { :snapshotted }
+
+    initialize_with { new(**attributes) }
+  end
+end

--- a/spec/factories/table.rb
+++ b/spec/factories/table.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :table, class: 'Readyset::Table' do
+    name { '"public"."cats"' }
+    status { :snapshotted }
+    description { 'Test description' }
+
+    initialize_with { new(**attributes) }
+  end
+end

--- a/spec/status_spec.rb
+++ b/spec/status_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Readyset::Status do
       status = Readyset::Status.call
 
       expect(status.database_connection_status).to eq(:connected)
-      expect(status.connection_count).to eq(1)
+      expect(status.connection_count).to be_a(Integer)
       expect(status.snapshot_status).to eq(:completed)
       expect(status.minimum_replication_offset).
         to match(/\([0-9A-F]{1,8}\/[0-9A-F]{1,8}, [0-9A-F]{1,8}\/[0-9A-F]{1,8}\)/)

--- a/spec/status_spec.rb
+++ b/spec/status_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Readyset::Status do
+  describe '.call' do
+    it "returns Readyset's current status" do
+      status = Readyset::Status.call
+
+      expect(status.database_connection_status).to eq(:connected)
+      expect(status.connection_count).to eq(1)
+      expect(status.snapshot_status).to eq(:completed)
+      expect(status.minimum_replication_offset).
+        to match(/\([0-9A-F]{1,8}\/[0-9A-F]{1,8}, [0-9A-F]{1,8}\/[0-9A-F]{1,8}\)/)
+      expect(status.maximum_replication_offset).
+        to match(/\([0-9A-F]{1,8}\/[0-9A-F]{1,8}, [0-9A-F]{1,8}\/[0-9A-F]{1,8}\)/)
+      expect(status.last_started_controller).to be_a(Time)
+      expect(status.last_started_replication).to be_a(Time)
+      expect(status.last_completed_snapshot).to be_a(Time)
+      expect(status.last_replicator_error).to be_nil
+    end
+  end
+
+  describe '.new' do
+    it "assigns the object's attributes correctly" do
+      status = Readyset::Status.new(**attributes_for(:status))
+
+      expect(status.connection_count).to eq(5)
+      expect(status.database_connection_status).to eq(:connected)
+      expect(status.last_completed_snapshot).to eq(Time.parse('2023-11-22 16:40:34'))
+      expect(status.last_replicator_error).to eq('test error')
+      expect(status.last_started_controller).to eq(Time.parse('2023-11-22 16:40:34'))
+      expect(status.last_started_replication).to eq(Time.parse('2023-11-22 16:40:34'))
+      expect(status.minimum_replication_offset).to eq('(0/33ED51B8, 0/33ED51E8)')
+      expect(status.maximum_replication_offset).to eq('(0/33ED51B8, 0/33ED51E8)')
+      expect(status.snapshot_status).to eq(:snapshotted)
+    end
+  end
+end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe Readyset::Table do
+  describe '.all' do
+    it 'returns the tables that exist on ReadySet' do
+      tables = Readyset::Table.all
+
+      expect(tables).to include(build(:table, description: ''))
+    end
+  end
+
+  describe '.new' do
+    it "assigns the object's attributes correctly" do
+      status = Readyset::Table.new(**attributes_for(:table))
+
+      expect(status.name).to eq('"public"."cats"')
+      expect(status.status).to eq(:snapshotted)
+      expect(status.description).to eq('Test description')
+    end
+  end
+end


### PR DESCRIPTION
**Note: This is based on #67 and should not be merged until that is merged**

Adds two new classes:
- A `ReadySet::Status` class that represents ReadySet's current status.
  The status can be queried by invoking `ReadySet::Status.call`.
- A `ReadySet::Table` class that represents the status of one of the
  tables in the database as it relates to ReadySet. The statuses for all
  the tables can be queried via `ReadySet::Table.all`.