### PR TITLE
rake: Fix migration tasks

### DIFF
--- a/lib/readyset/caches.rb
+++ b/lib/readyset/caches.rb
@@ -6,13 +6,12 @@ module Readyset
       attr_reader :caches
     end
 
-    def self.cache(id:, always: false)
+    def self.cache(always: false)
       @caches ||= Set.new
 
       query = yield
 
       @caches << Query::CachedQuery.new(
-        id: id,
         text: query.strip,
         always: always,
       )

--- a/lib/templates/caches.rb.tt
+++ b/lib/templates/caches.rb.tt
@@ -1,6 +1,6 @@
 class ReadysetCaches < Readyset::Caches
 <% queries.each do |query| -%>
-  cache id: <%= query.id.dump %>, always: <%= query.always %> do
+  cache always: <%= query.always %> do
     <<~SQL
       <%= query.text.gsub("\n", "\n      ") %>
     SQL

--- a/spec/caches_spec.rb
+++ b/spec/caches_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Readyset::Caches do
     end
 
     it 'adds a cache with the given attributes to the @caches ivar' do
-      query = build(:cached_query, always: true, count: nil, name: nil)
+      query = build(:cached_query, always: true, count: nil, id: nil, name: nil)
 
-      Readyset::Caches.cache(always: true, id: query.id) { query.text }
+      Readyset::Caches.cache(always: true) { query.text }
 
       caches = Readyset::Caches.instance_variable_get(:@caches)
       expect(caches.size).to eq(1)
@@ -16,9 +16,9 @@ RSpec.describe Readyset::Caches do
 
     context 'when no always parameter is passed' do
       it 'defaults the always parameter to false' do
-        query = build(:cached_query, count: nil, name: nil)
+        query = build(:cached_query, count: nil, id: nil, name: nil)
 
-        Readyset::Caches.cache(id: query.id) { query.text }
+        Readyset::Caches.cache { query.text }
 
         always = Readyset::Caches.instance_variable_get(:@caches).first.always
         expect(always).to eq(false)
@@ -28,8 +28,8 @@ RSpec.describe Readyset::Caches do
 
   describe '.caches' do
     it 'returns the caches stored in the @caches ivar' do
-      query = build(:cached_query, count: nil, name: nil)
-      Readyset::Caches.cache(always: query.always, id: query.id) { query.text }
+      query = build(:cached_query, count: nil, id: nil, name: nil)
+      Readyset::Caches.cache(always: query.always) { query.text }
 
       result = Readyset::Caches.caches
 


### PR DESCRIPTION
Previously, the migration task relied upon the query IDs generated by
ReadySet to determine what caches it needed to create or drop. This was
error prone because when caches are created via the gem, they are
created via the ID generated from the query string generated by Rails
when it invoked the queries. When the caches are created via the
*migration file*, they are created via the query string that was
obtained from calling `SHOW CACHES`, which has a number of rewrites,
including star expansion and fully-qualified table and column names.
Creating a cache from this query string would create a cache with a
different ID than creating the same cache from the Rails-generated query
string.

In addition, the migration task was always attempting to create caches
via the query ID from the migration file, which relies upon there being
an entry in SHOW PROXIED QUERIES for that query ID. This may not always
be the case, since it's possible a user may run the cache migrations
before routing queries for those caches.

This commit fixes these two issues by removing the dependence on query
IDs entirely and instead compares the query strings in the migration
file to the query strings in SHOW CACHES to determine which caches
should be created and dropped.

Finally, this commit also rewrites the rake task tests to run directly against
the Postgres and ReadySet instances running in CI to ensure that the logic is
sound.