### PR TITLE
railtie: Fix connection pools

### DIFF
--- a/lib/readyset/railtie.rb
+++ b/lib/readyset/railtie.rb
@@ -20,15 +20,14 @@ module Readyset
     initializer 'readyset.connection_pools' do |app|
       ActiveSupport.on_load(:after_initialize) do
         shard = Readyset.config.shard
-        config = ActiveRecord::Base.
-          configurations.
-          configs_for(name: shard.to_s, env_name: Rails.env, include_hidden: true).
-          configuration_hash
 
-        ActiveRecord::Base.connection_handler.
-          establish_connection(config, role: ActiveRecord.reading_role, shard: shard)
-        ActiveRecord::Base.connection_handler.
-          establish_connection(config, role: ActiveRecord.writing_role, shard: shard)
+        ActiveRecord::Base.connected_to(role: ActiveRecord.reading_role, shard: shard) do
+          ActiveRecord::Base.establish_connection(:readyset)
+        end
+
+        ActiveRecord::Base.connected_to(role: ActiveRecord.writing_role, shard: shard) do
+          ActiveRecord::Base.establish_connection(:readyset)
+        end
       end
     end
 

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -27,4 +27,18 @@ RSpec.describe Readyset::Railtie do
       expect(ActiveRecord::Relation.ancestors).to include(Readyset::RelationExtension)
     end
   end
+
+  describe 'readyset.connection_pools' do
+    it 'sets up connection pools for both the reading and writing roles' do
+      pools = ActiveRecord::Base.connection_handler.connection_pools
+      readyset_pool = pools.find { |pool| pool.shard == Readyset.config.shard }
+
+      expect(readyset_pool).not_to be_nil
+      expected_config = ActiveRecord::Base.
+        configurations.
+        configs_for(name: Readyset.config.shard.to_s, env_name: Rails.env, include_hidden: true)
+      expect(readyset_pool.db_config).to eq(expected_config)
+      expect(readyset_pool.connection_class).to eq(ActiveRecord::Base)
+    end
+  end
 end


### PR DESCRIPTION
Previously, the `readyset.connection_pool` railtie was setting up the connection pool for the gem by calling
`ConnectionHandler.establish_connection`, which was resulting in the connection pool's database key being set to that of the primary database instead of "readyset". This commit resolves the issue by relying directly on `ActiveRecord::Base.establish_connection` to set up the connection pool. It also adds unit test converage to ensure the connection pool is set up as expected.